### PR TITLE
Set variable to identify programs to iRODS.

### DIFF
--- a/src/programs/bamcollate2.cpp
+++ b/src/programs/bamcollate2.cpp
@@ -1419,6 +1419,13 @@ int main(int argc, char * argv[])
 		
 		::libmaus2::util::ArgInfo arginfo(argc,argv);
 	
+		#if defined(LIBMAUS2_HAVE_IRODS)
+		// set program name for iRODS identification
+		std::stringstream irods_id;
+		irods_id  << PACKAGE_NAME << ":" << arginfo.getProgFileName(arginfo.progname) << ":" << PACKAGE_VERSION;
+		setenv(SP_OPTION, irods_id.str().c_str(), 1);
+		#endif
+
 		for ( uint64_t i = 0; i < arginfo.restargs.size(); ++i )
 			if ( 
 				arginfo.restargs[i] == "-v"

--- a/src/programs/bammerge.cpp
+++ b/src/programs/bammerge.cpp
@@ -220,6 +220,13 @@ int main(int argc, char * argv[])
 
 		::libmaus2::util::ArgInfo const arginfo(argc,argv);
 		
+		#if defined(LIBMAUS2_HAVE_IRODS)
+		// set program name for iRODS identification
+		std::stringstream irods_id;
+		irods_id  << PACKAGE_NAME << ":" << arginfo.getProgFileName(arginfo.progname) << ":" << PACKAGE_VERSION;
+		setenv(SP_OPTION, irods_id.str().c_str(), 1);
+		#endif
+		
 		for ( uint64_t i = 0; i < arginfo.restargs.size(); ++i )
 			if ( 
 				arginfo.restargs[i] == "-v"

--- a/src/programs/bamtofastq.cpp
+++ b/src/programs/bamtofastq.cpp
@@ -1057,6 +1057,13 @@ int main(int argc, char * argv[])
 		
 		::libmaus2::util::ArgInfo arginfo(argc,argv);
 		
+		#if defined(LIBMAUS2_HAVE_IRODS)
+		// set program name for iRODS identification
+		std::stringstream irods_id;
+		irods_id  << PACKAGE_NAME << ":" << arginfo.getProgFileName(arginfo.progname) << ":" << PACKAGE_VERSION;
+		setenv(SP_OPTION, irods_id.str().c_str(), 1);
+		#endif
+
 		for ( uint64_t i = 0; i < arginfo.restargs.size(); ++i )
 			if ( 
 				arginfo.restargs[i] == "-v"


### PR DESCRIPTION
Set the environmental variable that is used as a program identifier and is sent to the iRODS server as part of the connection initialisation.
