### PR TITLE
Added an explicit iRODS disconnect to avoid the iRODS 4.19 crash.

### DIFF
--- a/src/programs/bamcollate2.cpp
+++ b/src/programs/bamcollate2.cpp
@@ -1525,6 +1525,14 @@ int main(int argc, char * argv[])
 		}
 
 		bamcollate2(arginfo);
+		
+		#if defined(LIBMAUS2_HAVE_IRODS)
+		// need a explicit call to disconnect to avoid atexit deallocation problems in iRODS 4.19+
+    		if (libmaus2::irods::IRodsSystem::defaultIrodsSystem)
+		{
+    	        	(libmaus2::irods::IRodsSystem::getDefaultIRodsSystem())->disconnect();
+		}
+		#endif
 
 		if ( arginfo.getValue<unsigned int>("verbose",getDefaultVerbose()) )
 			std::cerr << "[V] " << libmaus2::util::MemUsage() << " wall clock time " << rtc.formatTime(rtc.getElapsedSeconds()) << std::endl;

--- a/src/programs/bammerge.cpp
+++ b/src/programs/bammerge.cpp
@@ -206,6 +206,14 @@ int bammerge(libmaus2::util::ArgInfo const & arginfo)
 	{
 		Pindex->flush(std::string(indexfilename));
 	}
+	
+	#if defined(LIBMAUS2_HAVE_IRODS)
+	// need a explicit call to disconnect to avoid atexit deallocation problems in iRODS 4.19+
+    	if (libmaus2::irods::IRodsSystem::defaultIrodsSystem)
+	{
+    	        (libmaus2::irods::IRodsSystem::getDefaultIRodsSystem())->disconnect();
+	}
+	#endif
 
 	return EXIT_SUCCESS;
 }
@@ -226,7 +234,7 @@ int main(int argc, char * argv[])
 		irods_id  << PACKAGE_NAME << ":" << arginfo.getProgFileName(arginfo.progname) << ":" << PACKAGE_VERSION;
 		setenv(SP_OPTION, irods_id.str().c_str(), 1);
 		#endif
-
+		
 		for ( uint64_t i = 0; i < arginfo.restargs.size(); ++i )
 			if (
 				arginfo.restargs[i] == "-v"
@@ -266,7 +274,7 @@ int main(int argc, char * argv[])
 				std::cerr << std::endl;
 				return EXIT_SUCCESS;
 			}
-
+			
 		return bammerge(arginfo);
 	}
 	catch(std::exception const & ex)

--- a/src/programs/bamtofastq.cpp
+++ b/src/programs/bamtofastq.cpp
@@ -1240,7 +1240,15 @@ int main(int argc, char * argv[])
 		}
 
 		bamtofastq(arginfo);
-
+		
+		#if defined(LIBMAUS2_HAVE_IRODS)
+		// need a explicit call to disconnect to avoid atexit deallocation problems in iRODS 4.19+
+    		if (libmaus2::irods::IRodsSystem::defaultIrodsSystem)
+		{
+    	        	(libmaus2::irods::IRodsSystem::getDefaultIRodsSystem())->disconnect();
+		}
+		#endif
+		
 		std::cerr << "[V] " << libmaus2::util::MemUsage() << " wall clock time " << rtc.formatTime(rtc.getElapsedSeconds()) << std::endl;
 	}
 	catch(std::exception const & ex)


### PR DESCRIPTION
As of iRODS 4.19, any use of iRODS by libmaus2 crashes on program exit.  Both iRODS and libmaus2 use statically stored singleton objects that only go out of scope on program exit.  As objects are deallocated in reverse order of allocation, the iRODS objects that were created on rcConnect are destroyed before libmaus2 calls rcDisconnect leading to the disconnect code trying to access now invalid memory locations.  These changes add an explicit call to disconnect so that it happens before the program ending atexit handlers are called.
