### PR TITLE
No adapter clipping if remaining sequence would be a single base. 

### DIFF
--- a/src/biobambam2/ClipAdapters.cpp
+++ b/src/biobambam2/ClipAdapters.cpp
@@ -98,7 +98,7 @@ bool clipAdapters(
 		uint64_t const len = algn.decodeRead(R);
 		algn.decodeQual(Q);
 
-		if ( len - aclip )
+		if ( (len - aclip) > 1 )
 		{
 			if ( algn.isMapped() )
 			{


### PR DESCRIPTION
This should avoid a single '*' quality being interpreted as no quality values.  This should solve #39 